### PR TITLE
Added a 'selecting' event that is triggered before 'selected' and can be cancelled.

### DIFF
--- a/doc/jquery_typeahead.md
+++ b/doc/jquery_typeahead.md
@@ -324,6 +324,16 @@ The typeahead component triggers the following custom events.
   arguments: the jQuery event object, the suggestion object, and the name of 
   the dataset the suggestion belongs to.
 
+* `typeahead:selecting` – Triggered when a suggestion from the dropdown menu is 
+  selected, but before the `typeahead:selected` event and before the input box
+  value has been changed.
+  The event handler will be invoked with 3 arguments: the jQuery event object,
+  the suggestion object, and the name of the dataset the suggestion belongs to.
+  The selection of the item can be prevented by calling `.preventDefault()` on
+  the jQuery event object. If the event is canceled, `typeahead:selected` will
+  not be triggered, the input box will retain its previous value, and the
+  dropdown menu will not be closed.
+
 * `typeahead:selected` – Triggered when a suggestion from the dropdown menu is 
   selected. The event handler will be invoked with 3 arguments: the jQuery 
   event object, the suggestion object, and the name of the dataset the 

--- a/src/typeahead/event_bus.js
+++ b/src/typeahead/event_bus.js
@@ -29,8 +29,9 @@ var EventBus = (function() {
 
     trigger: function(type) {
       var args = [].slice.call(arguments, 1);
-
-      this.$el.trigger(namespace + type, args);
+      var event = jQuery.Event(namespace + type);
+      this.$el.trigger(event, args);
+      return event;
     }
   });
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -263,6 +263,11 @@ var Typeahead = (function() {
     },
 
     _select: function select(datum) {
+      var eventResult = this.eventBus.trigger('selecting', datum.raw, datum.datasetName);
+      if(eventResult.isDefaultPrevented()) {
+        return;
+      }
+
       this.input.setQuery(datum.value);
       this.input.setInputValue(datum.value, true);
 

--- a/test/playground.html
+++ b/test/playground.html
@@ -59,6 +59,9 @@
       <div class="typeahead-wrapper">
         <input class="mixed" type="text" placeholder="mixed">
       </div>
+      <div class="typeahead-wrapper">
+        <input class="cancel-select" type="text" placeholder="selection prevented">
+      </div>
     </div>
     </div>
 
@@ -300,10 +303,22 @@
         source: mixed.ttAdapter()
       });
 
+      $('.cancel-select').typeahead({
+        highlight: true
+      },
+      {
+        displayKey: 'val',
+        source: states.ttAdapter()
+      });
+      $('.cancel-select').on('typeahead:selecting', function(selectingEvent) {
+        // this is an example of preventing an item from being selected.
+        selectingEvent.preventDefault();
+      });
 
       $('input').on([
         'typeahead:initialized',
         'typeahead:initialized:err',
+        'typeahead:selecting',
         'typeahead:selected',
         'typeahead:autocompleted',
         'typeahead:cursorchanged',

--- a/test/typeahead_view_spec.js
+++ b/test/typeahead_view_spec.js
@@ -43,6 +43,50 @@ describe('Typeahead', function() {
 
       waitsFor(function() { return this.dropdown.close.callCount; });
     });
+
+    it('should trigger selecting event before value changes', function() {
+      var self = this;
+      var $e;
+      var selectedSpy;
+      var selectingEventTriggered = false;
+
+      var onSelecting = function () {
+        selectingEventTriggered = true;
+        expect(selectedSpy).not.toHaveBeenCalled();
+        expect(self.input.setQuery).not.toHaveBeenCalled();
+        expect(self.input.setInputValue).not.toHaveBeenCalled();
+      };
+
+      this.$input.on('typeahead:selecting', onSelecting);
+      this.$input.on('typeahead:selected', selectedSpy = jasmine.createSpy());
+
+      this.dropdown.trigger('suggestionClicked');
+
+      expect(selectingEventTriggered).toBe(true);
+      expect(selectedSpy).toHaveBeenCalled();
+      expect(self.input.setQuery).toHaveBeenCalled();
+      expect(self.input.setInputValue).toHaveBeenCalled();
+      waitsFor(function() { return this.dropdown.close.callCount; });
+    });
+
+    it('should allow canceling of selecting event', function() {
+      var self = this;
+      var $e;
+      var selectedSpy;
+
+      var onSelecting = function (selectingEvent) {
+        selectingEvent.preventDefault();
+      };
+
+      this.$input.on('typeahead:selecting', onSelecting);
+      this.$input.on('typeahead:selected', selectedSpy = jasmine.createSpy());
+
+      this.dropdown.trigger('suggestionClicked');
+
+      expect(selectedSpy).not.toHaveBeenCalled();
+      expect(self.input.setQuery).not.toHaveBeenCalled();
+      expect(self.input.setInputValue).not.toHaveBeenCalled();
+    });
   });
 
   describe('when dropdown triggers cursorMoved', function() {


### PR DESCRIPTION
## Intent

Added an event named `selecting` that allows the selection of an item to be cancelled. This would allow a user of Typeahead to detect items in the list that should be non-selectable or pass some validation. The selection could then be prevented, and a message could be shown or other action taken.
## Functional Changes

The change to `event_bus` is to let the `.trigger()` function return the event that was sent to handlers. This way anything that calls `eventBus.trigger(...)` can see the jQuery event after it is triggered, and see if any handlers tried to preventDefault() the event.
This has no functional affect on existing code since the return value would be ignored.

typeahead.js `_select()` now triggers the `selecting` event first, and checks to see if `.preventDefault()` was called on the event by any handlers. If it was, then it takes no further action. This prevents the change of the value of the widget, and stops the dropdown from closing.

Tests were added in typeahead_view_spec.js for automated testing and also a sample added to playground.html for manual testing.
